### PR TITLE
Release 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     },
     "require": {
         "php": ">=5.6",
-        "codemix/yii2-streamlog": "^1.3",
         "yiisoft/yii2": "^2.0"
     },
     "suggest": {
-        "silinternational/email-service-php-client": "To send log via email"
+        "codemix/yii2-streamlog": "To send log to a stream such as stdout using JsonStreamTarget",
+        "silinternational/email-service-php-client": "To send log via email using EmailServiceTarget"
     },
     "require-dev": {
         "behat/behat": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,15 @@
     },
     "require": {
         "php": ">=5.6",
-        "roave/security-advisories": "dev-master",
-        "silinternational/email-service-php-client": "^2.0.0",
         "yiisoft/yii2": "^2.0"
+    },
+    "suggest": {
+        "silinternational/email-service-php-client": "To send log via email"
     },
     "require-dev": {
         "behat/behat": "^3.3",
         "phpunit/phpunit": "^6.2 || ^5.7",
-        "fillup/fake-bower-assets": "^2.0"
+        "fillup/fake-bower-assets": "^2.0",
+        "roave/security-advisories": "dev-master"
     }
 }


### PR DESCRIPTION
### Changed
- Move `codemix/yii2-streamlog` from dependency to suggestion (since only used by JsonStreamTarget)
- Move `silinternational/email-service-php-client` from dependency to suggestion (since only used by EmailServiceTarget)

### Fixed
- Move Roave Security Advisories to dev-dependency

---

**Upgrading:**
- If you use either of the log targets that have dependencies that were moved to suggestions, you will now need to include the relevant dependency in your own composer.json file.