### PR TITLE
silinternational to sil-org rename

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @silinternational/php-devs
+* @sil-org/php-devs

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 SIL International
+Copyright (c) 2017 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,38 @@
 {
-    "name": "silinternational/yii2-json-log-targets",
-    "type": "library",
-    "description": "A collection of Yii2 log targets that format the log message as a JSON string.",
-    "keywords": ["yii2", "json", "log", "target", "file", "syslog"],
-    "license": "MIT",
-    "autoload": {
-        "psr-4": {
-            "Sil\\JsonLog\\": "src/"
-        }
-    },
-    "require": {
-        "php": ">=5.6",
-        "yiisoft/yii2": "^2.0"
-    },
-    "suggest": {
-        "codemix/yii2-streamlog": "To send log to a stream such as stdout using JsonStreamTarget",
-        "silinternational/email-service-php-client": "To send log via email using EmailServiceTarget"
-    },
-    "require-dev": {
-        "behat/behat": "^3.3",
-        "codemix/yii2-streamlog": "^1.3",
-        "phpunit/phpunit": "^8.0",
-        "fillup/fake-bower-assets": "^2.0",
-        "roave/security-advisories": "dev-master",
-        "silinternational/email-service-php-client":"^2.0.0"
-    },
-    "config": {
-        "allow-plugins": {
-            "yiisoft/yii2-composer": true
-        }
+  "name": "sil-org/yii2-json-log-targets",
+  "type": "library",
+  "description": "A collection of Yii2 log targets that format the log message as a JSON string.",
+  "keywords": ["yii2", "json", "log", "target", "file", "syslog"],
+  "license": "MIT",
+  "autoload": {
+    "psr-4": {
+      "Sil\\JsonLog\\": "src/"
     }
+  },
+  "require": {
+    "php": ">=5.6",
+    "yiisoft/yii2": "^2.0"
+  },
+  "suggest": {
+    "codemix/yii2-streamlog": "To send log to a stream such as stdout using JsonStreamTarget",
+    "silinternational/email-service-php-client": "To send log via email using EmailServiceTarget"
+  },
+  "require-dev": {
+    "behat/behat": "^3.3",
+    "codemix/yii2-streamlog": "^1.3",
+    "phpunit/phpunit": "^8.0",
+    "roave/security-advisories": "dev-master",
+    "silinternational/email-service-php-client":"^2.0.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "yiisoft/yii2-composer": true
+    }
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
+    }
+  ]
 }


### PR DESCRIPTION
### Change (non-breaking)
* CODEOWNERS group name to sil-org/php-devs
* License name from Sil International to Sil Global
* Switch to using asset packagist