### PR TITLE
Archive email service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ A collection of Yii2 log targets that format the log message as a JSON string.
 
 ### EmailServiceTarget
 
-The EmailServiceTarget is used to send logs to [ID Broker](https://github.com/sil-org/idp-id-broker)
-or [Email Service API](https://github.com/sil-org/email-service) (Archived)
+The EmailServiceTarget is used to send logs to the email endpoint
+in [ID Broker](https://github.com/sil-org/idp-id-broker).
 
 Note, this target can throw an exception that should be excluded in the target configuration to ensure a looping
-event is avoided. When used with ID Broker, the exception is `Sil\Idp\IdBroker\Client\ServiceException`. When
-used with Email Service, the exception is `Sil\EmailService\Client\EmailServiceClientException`.
+event is avoided. The exception is `Sil\Idp\IdBroker\Client\EmailServiceClientException`.
 
 As part of a Yii2 app configuration:
 
@@ -22,8 +21,7 @@ As part of a Yii2 app configuration:
                 'class' => 'Sil\JsonLog\target\EmailServiceTarget',
                 'levels' => ['error'],
                 'except' => [
-                    'Sil\Idp\IdBroker\Client\ServiceException',
-                    'Sil\EmailService\Client\EmailServiceClientException',
+                    'Sil\Idp\IdBroker\Client\EmailServiceClientException',
                 ],
                 'logVars' => [], // Disable logging of _SERVER, _POST, etc.
                 'message' => [

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ A collection of Yii2 log targets that format the log message as a JSON string.
 ## Usage
 
 ### EmailServiceTarget
-The EmailServiceTarget is used to send logs to our external 
-[Email Service API](https://github.com/silinternational/email-service)
 
-Note, this target can throw a Sil\EmailService\Client\EmailServiceClientException that should be excluded 
-from this target to ensure a looping event is avoided. 
+The EmailServiceTarget is used to send logs to [ID Broker](https://github.com/sil-org/idp-id-broker)
+or [Email Service API](https://github.com/sil-org/email-service) (Archived)
+
+Note, this target can throw an exception that should be excluded in the target configuration to ensure a looping
+event is avoided. When used with ID Broker, the exception is `Sil\Idp\IdBroker\Client\ServiceException`. When
+used with Email Service, the exception is `Sil\EmailService\Client\EmailServiceClientException`.
 
 As part of a Yii2 app configuration:
 
@@ -20,6 +22,7 @@ As part of a Yii2 app configuration:
                 'class' => 'Sil\JsonLog\target\EmailServiceTarget',
                 'levels' => ['error'],
                 'except' => [
+                    'Sil\Idp\IdBroker\Client\ServiceException',
                     'Sil\EmailService\Client\EmailServiceClientException',
                 ],
                 'logVars' => [], // Disable logging of _SERVER, _POST, etc.

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,19 @@
     }
   },
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.0",
     "yiisoft/yii2": "^2.0"
   },
   "suggest": {
     "codemix/yii2-streamlog": "To send log to a stream such as stdout using JsonStreamTarget",
-    "silinternational/email-service-php-client": "To send log via email using EmailServiceTarget"
+    "sil-org/idp-id-broker-php-client": "To send log via email using EmailServiceTarget"
   },
   "require-dev": {
     "behat/behat": "^3.3",
     "codemix/yii2-streamlog": "^1.3",
     "phpunit/phpunit": "^8.0",
     "roave/security-advisories": "dev-master",
-    "silinternational/email-service-php-client": "^2.0.0"
+    "sil-org/idp-id-broker-php-client": "^4.9.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/target/EmailServiceTarget.php
+++ b/src/target/EmailServiceTarget.php
@@ -2,7 +2,7 @@
 
 namespace Sil\JsonLog\target;
 
-use Sil\EmailService\Client\EmailServiceClient;
+use Sil\Idp\IdBroker\Client\IdBrokerClient;
 use Sil\JsonLog\JsonLogHelper;
 use yii\base\InvalidConfigException;
 use yii\helpers\Json;
@@ -87,12 +87,12 @@ class EmailServiceTarget extends Target
      */
     public function export()
     {
-        $emailService = new EmailServiceClient(
+        $emailService = new IdBrokerClient(
             $this->baseUrl,
             $this->accessToken,
             [
-                EmailServiceClient::ASSERT_VALID_IP_CONFIG => $this->assertValidIp,
-                EmailServiceClient::TRUSTED_IPS_CONFIG => $this->validIpRanges,
+                IdBrokerClient::ASSERT_VALID_IP_CONFIG => $this->assertValidIp,
+                IdBrokerClient::TRUSTED_IPS_CONFIG => $this->validIpRanges,
             ]
         );
 

--- a/src/target/EmailServiceTarget.php
+++ b/src/target/EmailServiceTarget.php
@@ -91,7 +91,7 @@ class EmailServiceTarget extends Target
             $this->baseUrl,
             $this->accessToken,
             [
-                IdBrokerClient::ASSERT_VALID_IP_CONFIG => $this->assertValidIp,
+                IdBrokerClient::ASSERT_VALID_BROKER_IP_CONFIG => $this->assertValidIp,
                 IdBrokerClient::TRUSTED_IPS_CONFIG => $this->validIpRanges,
             ]
         );


### PR DESCRIPTION
### Changed
- Use ID Broker email service as a replacement for the archived email-service library.