### PR TITLE
Don't init module if not enabled

### DIFF
--- a/src/target/EmailServiceTarget.php
+++ b/src/target/EmailServiceTarget.php
@@ -41,6 +41,10 @@ class EmailServiceTarget extends Target
      */
     public function init()
     {
+        if (!$this->enabled) {
+            return;
+        }
+
         parent::init();
         if (empty($this->baseUrl)) {
             throw new InvalidConfigException('The "baseUrl" option must be set for EmailServiceTarget::baseUrl.');


### PR DESCRIPTION
[ITSE-1255](https://support.gtis.sil.org/issue/ITSE-1255) yii2-json-log-targets #14: Only require a `to` address if enabled