### PR TITLE
upgrade GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run unit tests
         run: |
           touch local.env


### PR DESCRIPTION
[ITSE-2562 Upgrade GitHub Action steps that are using Node 20](https://support.gtis.sil.org/issue/ITSE-2562)

---

### Changed
- Update actions version references to latest available to include support for Node 24.